### PR TITLE
feat: attachment upload to directline

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
   "dependencies": {
     "botframework-directlinejs": "^0.9.17",
     "debug": "^3.1.0",
+    "form-data": "^2.3.3",
     "lodash": "^4.17.11",
     "mime-types": "^2.1.20",
+    "node-fetch": "^2.3.0",
     "uuid": "^3.3.2",
     "xhr2": "^0.1.4"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default {
     commonjs({
       exclude: 'node_modules/**'
     }),
-    buble(),
+    buble({ transforms: { asyncAwait: false } }),
     json()
   ]
 };


### PR DESCRIPTION
This PR adds a workaround to directline in order to be able to upload attachments even though it's not directly supported through the MS directline client (and as long as they don't fix that).