### PR TITLE
Remove restriction of media upload now that the workaround was released

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,3 @@ _Default: false_
 Botium simulates conversations with username _me_. Depending on your implementation, running multiple conversations with the same username could make them fail (for example, session handling).
 
 Setting this capability to _true_ will generate a new username (uuid) for each conversation.
-
-## Open Issues and Restrictions
-
-* Media Attachments currently cannot be sent, as Node.js environment is [not fully supported by DirectLine](https://github.com/Microsoft/BotFramework-DirectLineJS/issues/107)


### PR DESCRIPTION
I don't know if this should be fully removed or some kind of footnote should be added to clarify that it's working but that it's a workaround to what does not work out of the box with the official Directline client.