### PR TITLE
Add setUserId before directline connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ class BotiumConnectorDirectline3 {
     } else {
       this.me = (this.caps.DIRECTLINE3_ACTIVITY_TEMPLATE && _.get(this.caps.DIRECTLINE3_ACTIVITY_TEMPLATE, 'from.id')) || 'me'
     }
+    this.directLine.setUserId(this.me)
 
     const isValidActivityType = (activityType) => {
       const filter = this.caps.DIRECTLINE3_HANDLE_ACTIVITY_TYPES

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "better-queue": "^3.8.10",
-    "botframework-directlinejs": "^0.15.1",
+    "botframework-directlinejs": "^0.15.5",
     "debug": "^4.3.4",
     "form-data": "^4.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
I think before creating a conversation, you need to set userId. If this is not done, botium sends an empty token, but From.UserId must be set, so I used a temporary id (like "me"). However, even with enable DIRECTLINE3_GENERATE_USERNAME, it's not possible to create conversation with generated id, and parallel running tests results in message collisions between conversations. There's a pretty tricky workaround, but this solution seems logically correct to me